### PR TITLE
fix: Trim whitespace in digest auth parser

### DIFF
--- a/internal/sip/parser.go
+++ b/internal/sip/parser.go
@@ -78,8 +78,8 @@ func parseAuthHeader(headerValue string) map[string]string {
 	for _, part := range parts {
 		kv := strings.SplitN(strings.TrimSpace(part), "=", 2)
 		if len(kv) == 2 {
-			key := kv[0]
-			value := strings.Trim(kv[1], `"`)
+			key := strings.TrimSpace(kv[0])
+			value := strings.Trim(strings.TrimSpace(kv[1]), `"`)
 			result[key] = value
 		}
 	}

--- a/internal/sip/parser_test.go
+++ b/internal/sip/parser_test.go
@@ -53,6 +53,28 @@ func TestParseSIPRequest(t *testing.T) {
 		}
 	})
 
+	t.Run("Valid REGISTER with whitespace in Auth header", func(t *testing.T) {
+		rawReq := "REGISTER sip:registrar.example.com SIP/2.0\r\n" +
+			"Authorization: Digest username = \"alice\", realm = \"registrar.example.com\", nonce = \"dcd98b7102dd2f0e8b11d0f600bfb0c093\", uri = \"sip:registrar.example.com\", response = \"6629fae49393a053974507c4ef1\"\r\n" +
+			"Content-Length: 0\r\n\r\n"
+
+		req, err := ParseSIPRequest(rawReq)
+		if err != nil {
+			t.Fatalf("ParseSIPRequest failed: %v", err)
+		}
+
+		expectedAuth := map[string]string{
+			"username": "alice",
+			"realm":    "registrar.example.com",
+			"nonce":    "dcd98b7102dd2f0e8b11d0f600bfb0c093",
+			"uri":      "sip:registrar.example.com",
+			"response": "6629fae49393a053974507c4ef1",
+		}
+		if !reflect.DeepEqual(req.Authorization, expectedAuth) {
+			t.Errorf("Authorization header parsed incorrectly.\nExpected: %v\nGot:      %v", expectedAuth, req.Authorization)
+		}
+	})
+
 	t.Run("Malformed request line", func(t *testing.T) {
 		rawReq := "REGISTER sip:registrar.example.com\r\n"
 		_, err := ParseSIPRequest(rawReq)


### PR DESCRIPTION
The digest authentication parser in `internal/sip/parser.go` did not correctly trim whitespace from keys and values in the `Authorization` header.

If a SIP client sent an `Authorization` header with whitespace around the `=` separators (e.g., `username = "alice"`), the parser would fail to correctly look up the parameters. This resulted in authentication failures for valid users.

This change trims whitespace from both the key and the value during parsing, making the parser more robust and compliant with common client behaviors. A test case has been added to verify the fix.