### PR TITLE
Refactor: トランザクション状態を各トランザクションタイプ専用に分割

### DIFF
--- a/internal/sip/transaction.go
+++ b/internal/sip/transaction.go
@@ -20,18 +20,6 @@ var (
 	T4 = 5 * time.Second
 )
 
-// FSM States for Transactions
-type TxState int
-
-const (
-	TxStateTrying TxState = iota
-	TxStateProceeding
-	TxStateCompleted
-	TxStateConfirmed
-	TxStateTerminated
-	TxStateCalling // Client specific
-)
-
 // GenerateBranchID generates a new RFC3261 compliant branch ID.
 func GenerateBranchID() string {
 	b := make([]byte, 8) // 16 hex characters


### PR DESCRIPTION
`TxState` を、INVITE Client Transaction、Non-INVITE Client Transaction、INVITE Server Transaction、Non-INVITE Server Transaction のそれぞれ専用の状態に分割しました。

これにより、各トランザクションの状態が明確になり、問題発生時の解析が容易になります。