### PR TITLE
fix(proxy): Handle Max-Forwards correctly in initial requests

### DIFF
--- a/internal/sip/server.go
+++ b/internal/sip/server.go
@@ -420,6 +420,11 @@ func (s *SIPServer) proxyInitialRequest(originalReq *SIPRequest, upstreamTx Serv
 	}
 
 	fwdReq := s.prepareForwardedRequest(originalReq, registration.ContactURI)
+	if fwdReq == nil {
+		log.Printf("Dropping request for user %s due to Max-Forwards limit", toURI.User)
+		upstreamTx.Respond(BuildResponse(483, "Too Many Hops", originalReq, nil))
+		return
+	}
 
 	var clientTx ClientTransaction
 	switch fwdReq.Method {


### PR DESCRIPTION
Fixes a panic in the SIP proxy when handling initial requests with a low Max-Forwards value.

According to RFC3261 Section 16.6, a proxy must decrement the Max-Forwards header. If the value is 1 or less upon receipt, the proxy must not forward the request and should return a `483 Too Many Hops` response.

The previous implementation correctly decremented the header but failed to check if the request should be forwarded in `proxyInitialRequest`. This resulted in a nil pointer dereference and a panic when the code attempted to access the nil forwarded request.

This change adds a check in `proxyInitialRequest` to handle this case gracefully by sending the required 483 response.