### PR TITLE
feat: Add TCP transport support for SIP messages

### DIFF
--- a/internal/sip/response.go
+++ b/internal/sip/response.go
@@ -106,7 +106,8 @@ func BuildResponse(statusCode int, statusText string, req *SIPRequest, extraHead
 	}
 
 	// Copy essential headers from the request.
-	headersToCopy := []string{"Via", "From", "To", "Call-Id", "Cseq"}
+	// Use canonical header key forms.
+	headersToCopy := []string{"Via", "From", "To", "Call-ID", "CSeq"}
 	for _, h := range headersToCopy {
 		if val := req.GetHeader(h); val != "" {
 			// Add a tag to the 'To' header in the response, as required by RFC 3261,
@@ -116,7 +117,7 @@ func BuildResponse(statusCode int, statusText string, req *SIPRequest, extraHead
 				// would generate a unique tag for the dialog.
 				val = fmt.Sprintf("%s;tag=z9hG4bK-response-tag", val)
 			}
-			resp.Headers[h] = val
+			resp.Headers[strings.Title(h)] = val
 		}
 	}
 

--- a/internal/sip/transaction.go
+++ b/internal/sip/transaction.go
@@ -51,6 +51,7 @@ type BaseTransaction interface {
 	ID() string
 	Done() <-chan bool
 	Terminate()
+	Transport() Transport
 }
 
 // ServerTransaction represents a server-side transaction.

--- a/internal/sip/transaction_test.go
+++ b/internal/sip/transaction_test.go
@@ -25,10 +25,10 @@ func TestNonInviteServerTransactionHappyPath(t *testing.T) {
 		t.Fatalf("Failed to parse request: %v", err)
 	}
 
-	transport := newMockPacketConn()
 	remoteAddr := &net.UDPAddr{IP: net.ParseIP("1.1.1.1"), Port: 5060}
+	transport := newMockTransport("UDP", remoteAddr)
 
-	tx, err := NewNonInviteServerTx(req, transport, remoteAddr, "UDP")
+	tx, err := NewNonInviteServerTx(req, transport)
 	if err != nil {
 		t.Fatalf("Failed to create transaction: %v", err)
 	}
@@ -82,11 +82,11 @@ func TestInviteServerTransactionAckFlow(t *testing.T) {
 		t.Fatalf("Failed to parse request: %v", err)
 	}
 
-	transport := newMockPacketConn()
 	remoteAddr := &net.UDPAddr{IP: net.ParseIP("1.1.1.1"), Port: 5060}
+	transport := newMockTransport("UDP", remoteAddr)
 
 	// Create transaction
-	tx, err := NewInviteServerTx(req, transport, remoteAddr, "UDP")
+	tx, err := NewInviteServerTx(req, transport)
 	if err != nil {
 		t.Fatalf("Failed to create transaction: %v", err)
 	}
@@ -166,10 +166,10 @@ func TestInviteServerTransactionAckFlowReliable(t *testing.T) {
 				t.Fatalf("Failed to parse request: %v", err)
 			}
 
-			transport := newMockPacketConn()
 			remoteAddr := &net.TCPAddr{IP: net.ParseIP("1.1.1.1"), Port: 5060}
+			transport := newMockTransport(tt.proto, remoteAddr)
 
-			tx, err := NewInviteServerTx(req, transport, remoteAddr, tt.proto)
+			tx, err := NewInviteServerTx(req, transport)
 			if err != nil {
 				t.Fatalf("Failed to create transaction: %v", err)
 			}
@@ -229,10 +229,10 @@ func TestNonInviteServerTransactionReliable(t *testing.T) {
 				t.Fatalf("Failed to parse request: %v", err)
 			}
 
-			transport := newMockPacketConn()
 			remoteAddr := &net.TCPAddr{IP: net.ParseIP("1.1.1.1"), Port: 5060}
+			transport := newMockTransport(tt.proto, remoteAddr)
 
-			tx, err := NewNonInviteServerTx(req, transport, remoteAddr, tt.proto)
+			tx, err := NewNonInviteServerTx(req, transport)
 			if err != nil {
 				t.Fatalf("Failed to create transaction: %v", err)
 			}
@@ -281,10 +281,10 @@ func TestInviteServerTransactionNoRetransmissionReliable(t *testing.T) {
 				t.Fatalf("Failed to parse request: %v", err)
 			}
 
-			transport := newMockPacketConn()
 			remoteAddr := &net.TCPAddr{IP: net.ParseIP("1.1.1.1"), Port: 5060}
+			transport := newMockTransport(tt.proto, remoteAddr)
 
-			tx, err := NewInviteServerTx(req, transport, remoteAddr, tt.proto)
+			tx, err := NewInviteServerTx(req, transport)
 			if err != nil {
 				t.Fatalf("Failed to create transaction: %v", err)
 			}
@@ -338,9 +338,9 @@ func TestInviteClientTransactionSendsAckForNon2xxReliable(t *testing.T) {
 				t.Fatalf("Failed to parse request: %v", err)
 			}
 
-			transport := newMockPacketConn()
 			remoteAddr := &net.TCPAddr{IP: net.ParseIP("2.2.2.2"), Port: 5060}
-			tx, err := NewInviteClientTx(req, transport, remoteAddr, tt.proto)
+			transport := newMockTransport(tt.proto, remoteAddr)
+			tx, err := NewInviteClientTx(req, transport)
 			if err != nil {
 				t.Fatalf("Failed to create transaction: %v", err)
 			}
@@ -394,11 +394,11 @@ func TestInviteClientTimerAStop(t *testing.T) {
 		t.Fatalf("Failed to parse request: %v", err)
 	}
 
-	transport := newMockPacketConn()
 	remoteAddr := &net.UDPAddr{IP: net.ParseIP("2.2.2.2"), Port: 5060}
+	transport := newMockTransport("UDP", remoteAddr)
 
 	// Create the client transaction
-	tx, err := NewInviteClientTx(req, transport, remoteAddr, "UDP")
+	tx, err := NewInviteClientTx(req, transport)
 	if err != nil {
 		t.Fatalf("Failed to create transaction: %v", err)
 	}
@@ -457,9 +457,9 @@ func TestNonInviteClientTransactionReliable(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to parse request: %v", err)
 			}
-			transport := newMockPacketConn()
 			remoteAddr := &net.TCPAddr{IP: net.ParseIP("2.2.2.2"), Port: 5060}
-			tx, err := NewNonInviteClientTx(req, transport, remoteAddr, tt.proto)
+			transport := newMockTransport(tt.proto, remoteAddr)
+			tx, err := NewNonInviteClientTx(req, transport)
 			if err != nil {
 				t.Fatalf("Failed to create transaction: %v", err)
 			}
@@ -502,16 +502,16 @@ func TestInviteServerTransactionTerminatesOn2xx(t *testing.T) {
 				t.Fatalf("Failed to parse request: %v", err)
 			}
 
-			transport := newMockPacketConn()
 			var remoteAddr net.Addr
 			if tt.proto == "UDP" {
 				remoteAddr = &net.UDPAddr{IP: net.ParseIP("1.1.1.1"), Port: 5060}
 			} else {
 				remoteAddr = &net.TCPAddr{IP: net.ParseIP("1.1.1.1"), Port: 5060}
 			}
+			transport := newMockTransport(tt.proto, remoteAddr)
 
 			// Create transaction
-			tx, err := NewInviteServerTx(req, transport, remoteAddr, tt.proto)
+			tx, err := NewInviteServerTx(req, transport)
 			if err != nil {
 				t.Fatalf("Failed to create transaction: %v", err)
 			}

--- a/internal/sip/transport.go
+++ b/internal/sip/transport.go
@@ -1,0 +1,99 @@
+package sip
+
+import (
+	"fmt"
+	"io"
+	"net"
+)
+
+// Transport defines an interface for a SIP transport layer, which can be backed
+// by different network protocols like UDP, TCP, etc.
+type Transport interface {
+	// Writer is used to send a complete SIP message to the remote peer.
+	io.Writer
+	// GetProto returns the transport protocol name (e.g., "UDP", "TCP").
+	GetProto() string
+	// GetRemoteAddr returns the network address of the remote peer.
+	GetRemoteAddr() net.Addr
+	// Close terminates the transport connection if applicable.
+	Close() error
+}
+
+// --- UDP Transport ---
+
+// UDPTransport is a transport implementation for UDP.
+type UDPTransport struct {
+	conn     net.PacketConn
+	destAddr net.Addr
+}
+
+// NewUDPTransport creates a new UDP transport instance.
+func NewUDPTransport(conn net.PacketConn, destAddr net.Addr) *UDPTransport {
+	return &UDPTransport{
+		conn:     conn,
+		destAddr: destAddr,
+	}
+}
+
+// Write sends data to the destination address over the UDP connection.
+func (t *UDPTransport) Write(p []byte) (n int, err error) {
+	return t.conn.WriteTo(p, t.destAddr)
+}
+
+// GetProto returns "UDP".
+func (t *UDPTransport) GetProto() string {
+	return "UDP"
+}
+
+// GetRemoteAddr returns the destination network address.
+func (t *UDPTransport) GetRemoteAddr() net.Addr {
+	return t.destAddr
+}
+
+// Close for UDP is a no-op from the perspective of a single "transaction",
+// as the underlying PacketConn is shared and managed by the server listener.
+func (t *UDPTransport) Close() error {
+	return nil
+}
+
+// --- TCP Transport ---
+
+// TCPTransport is a transport implementation for TCP.
+type TCPTransport struct {
+	conn net.Conn
+}
+
+// NewTCPTransport creates a new TCP transport instance.
+func NewTCPTransport(conn net.Conn) *TCPTransport {
+	return &TCPTransport{
+		conn: conn,
+	}
+}
+
+// Write sends data over the TCP connection.
+// The provided byte slice should be a fully-formed SIP message.
+func (t *TCPTransport) Write(p []byte) (n int, err error) {
+	n, err = t.conn.Write(p)
+	if err != nil {
+		return n, err
+	}
+	if n < len(p) {
+		return n, fmt.Errorf("short write on tcp transport, wrote %d of %d bytes", n, len(p))
+	}
+	return n, nil
+}
+
+// GetProto returns "TCP".
+func (t *TCPTransport) GetProto() string {
+	return "TCP"
+}
+
+// GetRemoteAddr returns the remote network address of the connection.
+func (t *TCPTransport) GetRemoteAddr() net.Addr {
+	return t.conn.RemoteAddr()
+}
+
+// Close terminates the TCP connection.
+func (t *TCPTransport) Close() error {
+	return t.conn.Close()
+}


### PR DESCRIPTION
This commit introduces support for handling SIP messages over TCP, in addition to the existing UDP support.

Key changes include:

- A new `Transport` interface has been created to abstract the underlying network protocol (UDP or TCP), making the transaction and proxy layers protocol-agnostic.

- The SIP server has been updated to listen on both UDP and TCP ports concurrently using separate listeners.

- A message stream parser has been implemented for TCP to handle message framing based on the `Content-Length` header, as per RFC 3261.

- The proxy logic is now transport-aware. It inspects the transport of an incoming request and uses the same protocol for the outbound (proxied) leg of the call.

- `Via` headers are now generated with the correct transport type (`UDP` or `TCP`).

- The existing unit tests have been refactored to work with the new transport abstraction and to cover both reliable and unreliable transport scenarios.