### PR TITLE
fix(sip): Activate session timer after successful negotiation

### DIFF
--- a/internal/sip/b2bua.go
+++ b/internal/sip/b2bua.go
@@ -261,6 +261,12 @@ func (b *B2BUA) mediate(bLegTx ClientTransaction, aLegTx ServerTransaction) {
 				if res.StatusCode < 300 {
 					// Call was successful, set up dialog state.
 					b.establishDialogs(aLegRes, res)
+
+					// Activate the session timer if it was negotiated.
+					if se, err := aLegRes.SessionExpires(); err == nil && se != nil {
+						b.server.createOrUpdateSession(aLegTx, aLegRes, se)
+					}
+
 					// Wait for in-dialog messages
 					b.waitForDialogMessages()
 				}


### PR DESCRIPTION
The B2BUA correctly negotiated session timer parameters according to RFC 4028, but it failed to call the `createOrUpdateSession` function to activate the timer on the server.

This change adds the necessary function call within the B2BUA's `mediate` logic, ensuring that after a 2xx response is sent and the dialog is established, the session timer is properly started and tracked by the server.

This resolves a critical bug where sessions would never expire on the server side despite successful negotiation.