### PR TITLE
feat: Web画面にSIPセッション一覧を表示する機能を追加

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -34,14 +34,14 @@ func main() {
 	defer s.Close()
 	log.Printf("Storage initialized with database file: %s", *dbPath)
 
+	// Create SIP server
+	sipServer := sip.NewSIPServer(s, *realm)
+
 	// Create web server
-	webServer, err := web.NewServer(s, *realm)
+	webServer, err := web.NewServer(s, *realm, sipServer)
 	if err != nil {
 		log.Fatalf("Failed to create web server: %v", err)
 	}
-
-	// Create SIP server
-	sipServer := sip.NewSIPServer(s, *realm)
 
 	// --- Server Execution ---
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)

--- a/internal/sip/b2bua.go
+++ b/internal/sip/b2bua.go
@@ -23,14 +23,16 @@ type B2BUA struct {
 	done         chan bool
 	mu           sync.RWMutex
 	cancel       func()
+	StartTime    time.Time
 }
 
 // NewB2BUA creates and initializes a new B2BUA instance.
 func NewB2BUA(s *SIPServer, aLegTx ServerTransaction) *B2BUA {
 	return &B2BUA{
-		server: s,
-		aLegTx: aLegTx,
-		done:   make(chan bool),
+		server:    s,
+		aLegTx:    aLegTx,
+		done:      make(chan bool),
+		StartTime: time.Now(),
 	}
 }
 

--- a/internal/web/templates/sessions.html
+++ b/internal/web/templates/sessions.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Active SIP Sessions</title>
+    <style>
+        body { font-family: sans-serif; }
+        table { border-collapse: collapse; margin-top: 1em; }
+        th, td { border: 1px solid #ddd; padding: 8px; }
+        th { background-color: #f2f2f2; }
+        nav { margin-bottom: 1em; }
+    </style>
+</head>
+<body>
+    <h1>Active SIP Sessions</h1>
+    <nav>
+        <a href="/users">Manage Users</a> |
+        <a href="/sessions">Active Sessions</a>
+    </nav>
+    <table>
+        <thead>
+            <tr>
+                <th>Caller</th>
+                <th>Callee</th>
+                <th>Duration</th>
+                <th>Call-ID</th>
+            </tr>
+        </thead>
+        <tbody>
+            {{if .}}
+                {{range .}}
+                    <tr>
+                        <td>{{.Caller}}</td>
+                        <td>{{.Callee}}</td>
+                        <td>{{.Duration}}</td>
+                        <td>{{.CallID}}</td>
+                    </tr>
+                {{end}}
+            {{else}}
+                <tr>
+                    <td colspan="4">No active sessions.</td>
+                </tr>
+            {{end}}
+        </tbody>
+    </table>
+</body>
+</html>

--- a/internal/web/templates/users.html
+++ b/internal/web/templates/users.html
@@ -15,6 +15,10 @@
 </head>
 <body>
     <h1>SIP Server Users</h1>
+    <nav>
+        <a href="/users">Manage Users</a> |
+        <a href="/sessions">Active Sessions</a>
+    </nav>
     <a href="/users/new" class="add-link">Add New User</a>
     <table>
         <thead>

--- a/internal/web/templates/users_new.html
+++ b/internal/web/templates/users_new.html
@@ -15,6 +15,10 @@
 </head>
 <body>
     <h1>Add New SIP User</h1>
+    <nav>
+        <a href="/users">Manage Users</a> |
+        <a href="/sessions">Active Sessions</a>
+    </nav>
     <form action="/users/new" method="post">
         <label for="username">Username:</label>
         <input type="text" id="username" name="username" required>
@@ -24,6 +28,5 @@
 
         <button type="submit">Add User</button>
     </form>
-    <a href="/users" class="back-link">Back to User List</a>
 </body>
 </html>


### PR DESCRIPTION
Webインターフェースに、現在アクティブなSIPセッションの一覧を表示するページを追加しました。

主な変更点:
- `/sessions` エンドポイントを新設し、アクティブなセッション情報を表示します。
- `SIPServer` が保持しているアクティブなダイアログ（B2BUAインスタンス）の情報を取得し、Webサーバーに渡す仕組みを実装しました。
- `B2BUA` にセッション開始時刻を記録し、通話時間を表示できるようにしました。
- 既存のユーザー管理ページと新しいセッション一覧ページの間で、一貫したナビゲーションを提供します。