### PR TITLE
Refactor: Rename ALeg/BLeg to VirtualUAS/VirtualUAC

### DIFF
--- a/internal/sip/b2bua.go
+++ b/internal/sip/b2bua.go
@@ -11,46 +11,46 @@ import (
 )
 
 // B2BUAは単一の通話を管理し、バックツーバックユーザーエージェントとして機能します。
-// 2つのコールレッグを制御します: Aレッグ (UACからB2BUA) と Bレッグ (B2BUAからUAS)。
+// 2つの仮想UAを制御します: VirtualUAS (UACからB2BUA) と VirtualUAC (B2BUAからUAS)。
 type B2BUA struct {
-	server       *SIPServer
-	aLegTx       ServerTransaction // Aレッグ: 発呼者から
-	bLegTx       ClientTransaction // Bレッグ: 被呼者へ
-	aLegDialogID string
-	bLegDialogID string
-	aLegAck      *SIPRequest
-	bLegAck      *SIPRequest
-	done         chan bool
-	mu           sync.RWMutex
-	cancel       func()
-	StartTime    time.Time
+	server             *SIPServer
+	virtualUASTx       ServerTransaction // 仮想UASレッグ: 発呼者から
+	virtualUACTx       ClientTransaction // 仮想UACレッグ: 被呼者へ
+	virtualUASDialogID string
+	virtualUACDialogID string
+	virtualUASAck      *SIPRequest
+	virtualUACAck      *SIPRequest
+	done               chan bool
+	mu                 sync.RWMutex
+	cancel             func()
+	StartTime          time.Time
 }
 
 // NewB2BUAは新しいB2BUAインスタンスを作成して初期化します。
-func NewB2BUA(s *SIPServer, aLegTx ServerTransaction) *B2BUA {
+func NewB2BUA(s *SIPServer, virtualUASTx ServerTransaction) *B2BUA {
 	return &B2BUA{
-		server:    s,
-		aLegTx:    aLegTx,
-		done:      make(chan bool),
-		StartTime: time.Now(),
+		server:       s,
+		virtualUASTx: virtualUASTx,
+		done:         make(chan bool),
+		StartTime:    time.Now(),
 	}
 }
 
-// RunはB2BUAロジックを開始します。Bレッグの作成と、
+// RunはB2BUAロジックを開始します。仮想UACレッグの作成と、
 // 2つのレッグ間のコール状態の管理を担当します。
 func (b *B2BUA) Run(targetURI string) {
-	log.Printf("B2BUA started for A-leg tx %s, targeting %s", b.aLegTx.ID(), targetURI)
+	log.Printf("B2BUA started for Virtual-UAS-leg tx %s, targeting %s", b.virtualUASTx.ID(), targetURI)
 	defer close(b.done)
 
-	aLegReq := b.aLegTx.OriginalRequest()
+	virtualUASReq := b.virtualUASTx.OriginalRequest()
 
 	// セッションタイマーロジック - RFC 4028のセクション8.1
-	if aLegReq.Method == "INVITE" || aLegReq.Method == "UPDATE" {
+	if virtualUASReq.Method == "INVITE" || virtualUASReq.Method == "UPDATE" {
 		const b2buaMinSE = 1800 // 推奨通り30分。
 
-		se, err := aLegReq.SessionExpires()
+		se, err := virtualUASReq.SessionExpires()
 		if err != nil {
-			b.aLegTx.Respond(BuildResponse(400, "Bad Request", aLegReq, map[string]string{"Warning": "Malformed Session-Expires header"}))
+			b.virtualUASTx.Respond(BuildResponse(400, "Bad Request", virtualUASReq, map[string]string{"Warning": "Malformed Session-Expires header"}))
 			return
 		}
 
@@ -59,25 +59,24 @@ func (b *B2BUA) Run(targetURI string) {
 				// UACはタイマー対応なので、拒否できます。
 				log.Printf("Session-Expires %d is too small. Rejecting with 422.", se.Delta)
 				extraHeaders := map[string]string{"Min-SE": strconv.Itoa(b2buaMinSE)}
-				b.aLegTx.Respond(BuildResponse(422, "Session Interval Too Small", aLegReq, extraHeaders))
+				b.virtualUASTx.Respond(BuildResponse(422, "Session Interval Too Small", virtualUASReq, extraHeaders))
 				return
 			}
 		}
 	}
 
-
-	// 1. Bレッグ用に新しいINVITEリクエストを作成します。
-	bLegReq := b.createBLegInvite(aLegReq, targetURI)
-	if bLegReq == nil {
-		b.aLegTx.Respond(BuildResponse(500, "Server Internal Error", aLegReq, nil))
+	// 1. 仮想UACレッグ用に新しいINVITEリクエストを作成します。
+	virtualUACReq := b.createVirtualUACInvite(virtualUASReq, targetURI)
+	if virtualUACReq == nil {
+		b.virtualUASTx.Respond(BuildResponse(500, "Server Internal Error", virtualUASReq, nil))
 		return
 	}
 
-	// 2. Bレッグのトランスポートを決定します。
+	// 2. 仮想UACレッグのトランスポートを決定します。
 	contactURI, err := ParseSIPURI(targetURI)
 	if err != nil {
 		log.Printf("B2BUA: Invalid target URI %s: %v", targetURI, err)
-		b.aLegTx.Respond(BuildResponse(400, "Bad Request", aLegReq, map[string]string{"Warning": "Invalid target URI"}))
+		b.virtualUASTx.Respond(BuildResponse(400, "Bad Request", virtualUASReq, map[string]string{"Warning": "Invalid target URI"}))
 		return
 	}
 	destPort := "5060"
@@ -85,14 +84,14 @@ func (b *B2BUA) Run(targetURI string) {
 		destPort = contactURI.Port
 	}
 	destHost := contactURI.Host
-	proto := strings.ToUpper(b.aLegTx.Transport().GetProto())
+	proto := strings.ToUpper(b.virtualUASTx.Transport().GetProto())
 
 	var outboundTransport Transport
 	if proto == "UDP" {
 		destAddr, err := net.ResolveUDPAddr("udp", destHost+":"+destPort)
 		if err != nil {
 			log.Printf("B2BUA: Could not resolve destination UDP address '%s': %v", targetURI, err)
-			b.aLegTx.Respond(BuildResponse(503, "Service Unavailable", aLegReq, nil))
+			b.virtualUASTx.Respond(BuildResponse(503, "Service Unavailable", virtualUASReq, nil))
 			return
 		}
 		outboundTransport = NewUDPTransport(b.server.udpConn, destAddr)
@@ -100,100 +99,100 @@ func (b *B2BUA) Run(targetURI string) {
 		destAddr, err := net.ResolveTCPAddr("tcp", destHost+":"+destPort)
 		if err != nil {
 			log.Printf("B2BUA: Could not resolve destination TCP address '%s': %v", targetURI, err)
-			b.aLegTx.Respond(BuildResponse(503, "Service Unavailable", aLegReq, nil))
+			b.virtualUASTx.Respond(BuildResponse(503, "Service Unavailable", virtualUASReq, nil))
 			return
 		}
 		conn, err := net.DialTCP("tcp", nil, destAddr)
 		if err != nil {
 			log.Printf("B2BUA: Could not connect to destination TCP address '%s': %v", targetURI, err)
-			b.aLegTx.Respond(BuildResponse(503, "Service Unavailable", aLegReq, nil))
+			b.virtualUASTx.Respond(BuildResponse(503, "Service Unavailable", virtualUASReq, nil))
 			return
 		}
 		outboundTransport = NewTCPTransport(conn)
 	}
 
-	// 3. Bレッグのクライアントトランザクションを作成して実行します。
-	bLegTx, err := NewInviteClientTx(bLegReq, outboundTransport)
+	// 3. 仮想UACレッグのクライアントトランザクションを作成して実行します。
+	virtualUACTx, err := NewInviteClientTx(virtualUACReq, outboundTransport)
 	if err != nil {
-		log.Printf("B2BUA: Failed to create B-leg client transaction: %v", err)
-		b.aLegTx.Respond(BuildResponse(500, "Server Internal Error", aLegReq, nil))
+		log.Printf("B2BUA: Failed to create Virtual-UAC-leg client transaction: %v", err)
+		b.virtualUASTx.Respond(BuildResponse(500, "Server Internal Error", virtualUASReq, nil))
 		return
 	}
 	b.mu.Lock()
-	b.bLegTx = bLegTx
+	b.virtualUACTx = virtualUACTx
 	b.mu.Unlock()
-	b.server.txManager.Add(bLegTx)
+	b.server.txManager.Add(virtualUACTx)
 
-	log.Printf("B2BUA: A-leg tx %s created B-leg tx %s", b.aLegTx.ID(), b.bLegTx.ID())
+	log.Printf("B2BUA: Virtual-UAS-leg tx %s created Virtual-UAC-leg tx %s", b.virtualUASTx.ID(), b.virtualUACTx.ID())
 
 	// 4. 2つのレッグ間を仲介します。
-	b.mediate(bLegTx, b.aLegTx)
+	b.mediate(virtualUACTx, b.virtualUASTx)
 }
 
-// createBLegInviteは、Aレッグのリクエストに基づいてBレッグの新しいINVITEリクエストを作成します。
-func (b *B2BUA) createBLegInvite(aLegReq *SIPRequest, targetURI string) *SIPRequest {
-	bLegReq := &SIPRequest{
+// createVirtualUACInviteは、仮想UASレッグのリクエストに基づいて仮想UACレッグの新しいINVITEリクエストを作成します。
+func (b *B2BUA) createVirtualUACInvite(virtualUASReq *SIPRequest, targetURI string) *SIPRequest {
+	virtualUACReq := &SIPRequest{
 		Method:  "INVITE",
 		URI:     targetURI,
-		Proto:   aLegReq.Proto,
+		Proto:   virtualUASReq.Proto,
 		Headers: make(map[string]string),
-		Body:    aLegReq.Body, // SDPボディをそのまま渡す
+		Body:    virtualUASReq.Body, // SDPボディをそのまま渡す
 	}
 
 	// ほとんどのヘッダーをコピーしますが、新しいダイアログ形成ヘッダーを作成します。
-	for k, v := range aLegReq.Headers {
+	for k, v := range virtualUASReq.Headers {
 		lowerK := strings.ToLower(k)
 		// B2BUAが自身で作成するダイアログ固有のヘッダーは除外します。
 		if lowerK != "from" && lowerK != "to" && lowerK != "call-id" && lowerK != "cseq" &&
 			lowerK != "via" && lowerK != "contact" && lowerK != "record-route" && lowerK != "route" {
-			bLegReq.Headers[k] = v
+			virtualUACReq.Headers[k] = v
 		}
 	}
 
 	// 新しいダイアログ識別子を作成します。
-	bLegReq.Headers["Call-ID"] = GenerateCallID()
+	virtualUACReq.Headers["Call-ID"] = GenerateCallID()
 
 	// 表示名を維持しつつ、新しいタグでFromヘッダーを再構築します。
-	fromHeader := aLegReq.GetHeader("From")
+	fromHeader := virtualUASReq.GetHeader("From")
 	// タグを取り除く簡単で堅牢な方法は、";tag="で分割することです。
 	fromBase := strings.Split(fromHeader, ";tag=")[0]
 	fromTag := GenerateTag()
-	bLegReq.Headers["From"] = fmt.Sprintf("%s;tag=%s", fromBase, fromTag)
+	virtualUACReq.Headers["From"] = fmt.Sprintf("%s;tag=%s", fromBase, fromTag)
 
 	// Toヘッダーはターゲットに基づいている必要があります
 	toURI, err := ParseSIPURI(targetURI)
 	if err != nil {
 		return nil
 	}
-	bLegReq.Headers["To"] = fmt.Sprintf("<sip:%s@%s>", toURI.User, toURI.Host)
+	virtualUACReq.Headers["To"] = fmt.Sprintf("<sip:%s@%s>", toURI.User, toURI.Host)
 
-	bLegReq.Headers["CSeq"] = "1 INVITE" // CSeqは新しいダイアログに対して独立しています
+	virtualUACReq.Headers["CSeq"] = "1 INVITE" // CSeqは新しいダイアログに対して独立しています
 
 	// B2BUAのContactヘッダー。
-	bLegReq.Headers["Contact"] = fmt.Sprintf("<sip:%s>", b.server.listenAddr)
+	virtualUACReq.Headers["Contact"] = fmt.Sprintf("<sip:%s>", b.server.listenAddr)
 
 	// トランザクション層は、ブランチIDを決定するためにViaヘッダーが存在することを要求します。
 	branch := GenerateBranchID()
-	via := fmt.Sprintf("SIP/2.0/%s %s;branch=%s", strings.ToUpper(b.aLegTx.Transport().GetProto()), b.server.listenAddr, branch)
-	bLegReq.Headers["Via"] = via
+	via := fmt.Sprintf("SIP/2.0/%s %s;branch=%s", strings.ToUpper(b.virtualUASTx.Transport().GetProto()), b.server.listenAddr, branch)
+	virtualUACReq.Headers["Via"] = via
 
-	bLegReq.Headers["Max-Forwards"] = "69" // Max-Forwardsをデクリメント
+	virtualUACReq.Headers["Max-Forwards"] = "69" // Max-Forwardsをデクリメント
 
-	return bLegReq
+	return virtualUACReq
 }
 
 // mediateは2つのレッグ間のレスポンスとリクエストのフローを処理します。
-func (b *B2BUA) mediate(bLegTx ClientTransaction, aLegTx ServerTransaction) {
-	aLegReq := aLegTx.OriginalRequest()
+func (b *B2BUA) mediate(virtualUACTx ClientTransaction, virtualUASTx ServerTransaction) {
+	virtualUASReq := virtualUASTx.OriginalRequest()
 
 	for {
 		select {
-		// Bレッグ（被呼者）からのレスポンスを処理します
-		case res, ok := <-bLegTx.Responses():
+		// 仮想UACレッグ（被呼者）からのレスポンスを処理します
+		case res, ok := <-virtualUACTx.Responses():
 			if !ok {
 				return
 			}
-			log.Printf("B2BUA: Received response %d from B-leg tx %s", res.StatusCode, bLegTx.ID())
+			log.Printf("B2BUA: Received response %d from Virtual-UAC-leg tx %s", res.StatusCode, virtualUACTx.ID())
 
 			// 422 Session Interval Too Smallを再試行して処理します
 			if res.StatusCode == 422 {
@@ -201,7 +200,7 @@ func (b *B2BUA) mediate(bLegTx ClientTransaction, aLegTx ServerTransaction) {
 				if err == nil && minSE > 0 {
 					log.Printf("B2BUA: Handling 422, retrying with Min-SE: %d", minSE)
 					// 更新されたSession-Expiresで新しいリクエストを作成します
-					retryReq := bLegTx.OriginalRequest().Clone()
+					retryReq := virtualUACTx.OriginalRequest().Clone()
 					retryReq.Headers["Session-Expires"] = strconv.Itoa(minSE)
 
 					// CSeqをインクリメント
@@ -214,36 +213,35 @@ func (b *B2BUA) mediate(bLegTx ClientTransaction, aLegTx ServerTransaction) {
 
 					// 新しいトランザクションのために新しいViaヘッダーを追加します
 					branch := GenerateBranchID()
-					via := fmt.Sprintf("SIP/2.0/%s %s;branch=%s", strings.ToUpper(b.aLegTx.Transport().GetProto()), b.server.listenAddr, branch)
+					via := fmt.Sprintf("SIP/2.0/%s %s;branch=%s", strings.ToUpper(b.virtualUASTx.Transport().GetProto()), b.server.listenAddr, branch)
 					retryReq.Headers["Via"] = via
 
-					// 再試行のために新しいBレッグクライアントトランザクションを作成して実行します
-					newBLegTx, err := NewInviteClientTx(retryReq, bLegTx.Transport())
+					// 再試行のために新しい仮想UACレッグクライアントトランザクションを作成して実行します
+					newVirtualUACTx, err := NewInviteClientTx(retryReq, virtualUACTx.Transport())
 					if err != nil {
-						log.Printf("B2BUA: Failed to create retry B-leg client transaction: %v", err)
-						aLegTx.Respond(BuildResponse(500, "Server Internal Error", aLegReq, nil))
+						log.Printf("B2BUA: Failed to create retry Virtual-UAC-leg client transaction: %v", err)
+						virtualUASTx.Respond(BuildResponse(500, "Server Internal Error", virtualUASReq, nil))
 						return
 					}
 					b.mu.Lock()
-					b.bLegTx = newBLegTx
+					b.virtualUACTx = newVirtualUACTx
 					b.mu.Unlock()
-					b.server.txManager.Add(newBLegTx)
+					b.server.txManager.Add(newVirtualUACTx)
 
 					// 新しいトランザクションで仲介を続行します
-					b.mediate(newBLegTx, aLegTx)
+					b.mediate(newVirtualUACTx, virtualUASTx)
 					return // この仲介ループを終了します
 				}
 			}
-
 
 			// 200 OKを受け取った場合、Session-Expiresヘッダーを自分たちで追加する必要があるかもしれません
 			if res.StatusCode >= 200 && res.StatusCode < 300 {
 				// セッションタイマー: UASがタイマーをサポートしていない (RFC 4028 セクション 8.1.2)
 				// 元のリクエストがタイマーを要求したが、2xxレスポンスにタイマーがない場合、
 				// B2BUAはそれを挿入しなければなりません(MUST)。
-				if se, _ := aLegReq.SessionExpires(); se != nil { // タイマーが要求されました
+				if se, _ := virtualUASReq.SessionExpires(); se != nil { // タイマーが要求されました
 					if resSE, _ := res.SessionExpires(); resSE == nil { // 2xxレスポンスにタイマーがありません
-						log.Printf("B2BUA: UAS did not include Session-Expires in 2xx. Adding it now for A-leg.")
+						log.Printf("B2BUA: UAS did not include Session-Expires in 2xx. Adding it now for Virtual-UAS-leg.")
 						res.Headers["Session-Expires"] = fmt.Sprintf("%d;refresher=uac", se.Delta)
 						if existing, ok := res.Headers["Require"]; ok {
 							res.Headers["Require"] = "timer, " + existing
@@ -254,19 +252,19 @@ func (b *B2BUA) mediate(bLegTx ClientTransaction, aLegTx ServerTransaction) {
 				}
 			}
 
-			// Aレッグに対応するレスポンスを作成します。
-			aLegRes := b.createALegResponse(aLegReq, res)
-			aLegTx.Respond(aLegRes)
+			// 仮想UASレッグに対応するレスポンスを作成します。
+			virtualUASRes := b.createVirtualUASResponse(virtualUASReq, res)
+			virtualUASTx.Respond(virtualUASRes)
 
 			// これが最終レスポンスの場合、INVITEトランザクションは終了です。
 			if res.StatusCode >= 200 {
 				if res.StatusCode < 300 {
 					// 通話は成功し、ダイアログ状態を設定します。
-					b.establishDialogs(aLegRes, res)
+					b.establishDialogs(virtualUASRes, res)
 
 					// 交渉された場合、セッションタイマーをアクティブにします。
-					if se, err := aLegRes.SessionExpires(); err == nil && se != nil {
-						b.server.createOrUpdateSession(aLegTx, aLegRes, se)
+					if se, err := virtualUASRes.SessionExpires(); err == nil && se != nil {
+						b.server.createOrUpdateSession(virtualUASTx, virtualUASRes, se)
 					}
 
 					// ダイアログ内のメッセージを待ちます
@@ -275,35 +273,35 @@ func (b *B2BUA) mediate(bLegTx ClientTransaction, aLegTx ServerTransaction) {
 				return // INVITEトランザクションの仲介を終了します
 			}
 
-		// Aレッグ（発呼者）からのキャンセルを処理します
-		case <-aLegTx.Done():
-			log.Printf("B2BUA: A-leg tx %s terminated.", aLegTx.ID())
-			// Bレッグがまだアクティブな場合は、キャンセルします。
+		// 仮想UASレッグ（発呼者）からのキャンセルを処理します
+		case <-virtualUASTx.Done():
+			log.Printf("B2BUA: Virtual-UAS-leg tx %s terminated.", virtualUASTx.ID())
+			// 仮想UACレッグがまだアクティブな場合は、キャンセルします。
 			select {
-			case <-bLegTx.Done():
-				// Bレッグはすでに終了しており、何もすることはありません。
+			case <-virtualUACTx.Done():
+				// 仮想UACレッグはすでに終了しており、何もすることはありません。
 			default:
-				log.Printf("B2BUA: A-leg terminated, cancelling B-leg tx %s", bLegTx.ID())
-				cancelReq := createCancelRequest(bLegTx.OriginalRequest())
-				bLegTx.Transport().Write([]byte(cancelReq.String()))
-				bLegTx.Terminate()
+				log.Printf("B2BUA: Virtual-UAS-leg terminated, cancelling Virtual-UAC-leg tx %s", virtualUACTx.ID())
+				cancelReq := createCancelRequest(virtualUACTx.OriginalRequest())
+				virtualUACTx.Transport().Write([]byte(cancelReq.String()))
+				virtualUACTx.Terminate()
 			}
 			return
 
 		case <-time.After(32 * time.Second): // フェイルセーフタイマー
-			log.Printf("B2BUA: Timeout waiting for response on B-leg tx %s", bLegTx.ID())
-			aLegTx.Respond(BuildResponse(408, "Request Timeout", aLegReq, nil))
-			bLegTx.Terminate()
+			log.Printf("B2BUA: Timeout waiting for response on Virtual-UAC-leg tx %s", virtualUACTx.ID())
+			virtualUASTx.Respond(BuildResponse(408, "Request Timeout", virtualUASReq, nil))
+			virtualUACTx.Terminate()
 			return
 		}
 	}
 }
 
-// createALegResponseは、Bレッグのレスポンスに基づいてAレッグのレスポンスを作成します。
-func (b *B2BUA) createALegResponse(aLegReq *SIPRequest, bLegRes *SIPResponse) *SIPResponse {
+// createVirtualUASResponseは、仮想UACレッグのレスポンスに基づいて仮想UASレッグのレスポンスを作成します。
+func (b *B2BUA) createVirtualUASResponse(virtualUASReq *SIPRequest, virtualUACRes *SIPResponse) *SIPResponse {
 	extraHeaders := make(map[string]string)
-	// Bレッグのレスポンスからダイアログ固有でないすべてのヘッダーをコピーします。
-	for k, v := range bLegRes.Headers {
+	// 仮想UACレッグのレスポンスからダイアログ固有でないすべてのヘッダーをコピーします。
+	for k, v := range virtualUACRes.Headers {
 		lowerK := strings.ToLower(k)
 		switch lowerK {
 		case "via", "from", "to", "call-id", "cseq", "contact", "record-route":
@@ -313,41 +311,41 @@ func (b *B2BUA) createALegResponse(aLegReq *SIPRequest, bLegRes *SIPResponse) *S
 		}
 	}
 
-	// Bレッグのレスポンスからステータスコードと理由を再利用します。
-	aLegRes := BuildResponse(bLegRes.StatusCode, bLegRes.Reason, aLegReq, extraHeaders)
+	// 仮想UACレッグのレスポンスからステータスコードと理由を再利用します。
+	virtualUASRes := BuildResponse(virtualUACRes.StatusCode, virtualUACRes.Reason, virtualUASReq, extraHeaders)
 
-	// Bレッグのレスポンスが2xxだった場合、独自のContactヘッダーとToタグを追加する必要があります。
-	if aLegRes.StatusCode >= 200 && aLegRes.StatusCode < 300 {
-		aLegRes.Headers["Contact"] = fmt.Sprintf("<sip:%s>", b.server.listenAddr)
-		if getTag(aLegRes.Headers["To"]) == "" {
-			aLegRes.Headers["To"] = fmt.Sprintf("%s;tag=%s", aLegRes.Headers["To"], GenerateTag())
+	// 仮想UACレッグのレスポンスが2xxだった場合、独自のContactヘッダーとToタグを追加する必要があります。
+	if virtualUASRes.StatusCode >= 200 && virtualUASRes.StatusCode < 300 {
+		virtualUASRes.Headers["Contact"] = fmt.Sprintf("<sip:%s>", b.server.listenAddr)
+		if getTag(virtualUASRes.Headers["To"]) == "" {
+			virtualUASRes.Headers["To"] = fmt.Sprintf("%s;tag=%s", virtualUASRes.Headers["To"], GenerateTag())
 		}
 	}
 
 	// Via、From、To、Call-ID、およびCSeqヘッダーは、BuildResponseによってすでに正しく設定されています。
-	return aLegRes
+	return virtualUASRes
 }
 
 // establishDialogsは2xxレスポンスの後にダイアログ識別子を保存します。
-func (b *B2BUA) establishDialogs(aLegRes, bLegRes *SIPResponse) {
+func (b *B2BUA) establishDialogs(virtualUASRes, virtualUACRes *SIPResponse) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	b.aLegDialogID = getDialogID(
-		aLegRes.GetHeader("Call-ID"),
-		getTag(aLegRes.GetHeader("From")),
-		getTag(aLegRes.GetHeader("To")),
+	b.virtualUASDialogID = getDialogID(
+		virtualUASRes.GetHeader("Call-ID"),
+		getTag(virtualUASRes.GetHeader("From")),
+		getTag(virtualUASRes.GetHeader("To")),
 	)
-	b.bLegDialogID = getDialogID(
-		bLegRes.GetHeader("Call-ID"),
-		getTag(bLegRes.GetHeader("From")),
-		getTag(bLegRes.GetHeader("To")),
+	b.virtualUACDialogID = getDialogID(
+		virtualUACRes.GetHeader("Call-ID"),
+		getTag(virtualUACRes.GetHeader("From")),
+		getTag(virtualUACRes.GetHeader("To")),
 	)
 
-	b.server.dialogs.Store(b.aLegDialogID, b)
-	b.server.dialogs.Store(b.bLegDialogID, b)
+	b.server.dialogs.Store(b.virtualUASDialogID, b)
+	b.server.dialogs.Store(b.virtualUACDialogID, b)
 
-	log.Printf("B2BUA: Established dialogs. A-leg: %s, B-leg: %s", b.aLegDialogID, b.bLegDialogID)
+	log.Printf("B2BUA: Established dialogs. Virtual-UAS-leg: %s, Virtual-UAC-leg: %s", b.virtualUASDialogID, b.virtualUACDialogID)
 }
 
 // waitForDialogMessagesは、BYEやre-INVITEなどのダイアログ内リクエストを処理するためのメインループです。
@@ -359,30 +357,30 @@ func (b *B2BUA) waitForDialogMessages() {
 
 // Cancelは、アップストリームトランザクションがキャンセルされたときに呼び出されます。
 func (b *B2BUA) Cancel() {
-	log.Printf("B2BUA: Received external cancel for A-leg tx %s", b.aLegTx.ID())
+	log.Printf("B2BUA: Received external cancel for Virtual-UAS-leg tx %s", b.virtualUASTx.ID())
 
 	b.mu.RLock()
-	bLegTx := b.bLegTx
+	virtualUACTx := b.virtualUACTx
 	b.mu.RUnlock()
 
-	// BレッグのINVITEトランザクションがまだ処理中の場合、キャンセルします。
-	if bLegTx != nil {
+	// 仮想UACレッグのINVITEトランザクションがまだ処理中の場合、キャンセルします。
+	if virtualUACTx != nil {
 		select {
-		case <-bLegTx.Done():
+		case <-virtualUACTx.Done():
 			// トランザクションはすでに終了しており、キャンセルするものはありません。
 		default:
-			log.Printf("B2BUA: Sending CANCEL to B-leg tx %s", bLegTx.ID())
-			cancelReq := createCancelRequest(bLegTx.OriginalRequest())
-			if _, err := bLegTx.Transport().Write([]byte(cancelReq.String())); err != nil {
-				log.Printf("B2BUA: Error sending CANCEL to B-leg: %v", err)
+			log.Printf("B2BUA: Sending CANCEL to Virtual-UAC-leg tx %s", virtualUACTx.ID())
+			cancelReq := createCancelRequest(virtualUACTx.OriginalRequest())
+			if _, err := virtualUACTx.Transport().Write([]byte(cancelReq.String())); err != nil {
+				log.Printf("B2BUA: Error sending CANCEL to Virtual-UAC-leg: %v", err)
 			}
-			bLegTx.Terminate()
+			virtualUACTx.Terminate()
 		}
 	}
 
 	// 元のINVITEに487で応答します。
-	if err := b.aLegTx.Respond(BuildResponse(487, "Request Terminated", b.aLegTx.OriginalRequest(), nil)); err != nil {
-		log.Printf("B2BUA: Error sending 487 response to A-leg: %v", err)
+	if err := b.virtualUASTx.Respond(BuildResponse(487, "Request Terminated", b.virtualUASTx.OriginalRequest(), nil)); err != nil {
+		log.Printf("B2BUA: Error sending 487 response to Virtual-UAS-leg: %v", err)
 	}
 
 	b.cleanup()
@@ -390,92 +388,92 @@ func (b *B2BUA) Cancel() {
 
 // HandleInDialogRequestは、このB2BUAによって管理されている既存のダイアログに属するリクエストを処理します。
 func (b *B2BUA) HandleInDialogRequest(req *SIPRequest, tx ServerTransaction) {
-	log.Printf("B2BUA: Handling in-dialog %s for dialog %s", req.Method, b.aLegDialogID)
+	log.Printf("B2BUA: Handling in-dialog %s for dialog %s", req.Method, b.virtualUASDialogID)
 
 	b.mu.Lock()
-	aLegDialogID := b.aLegDialogID
+	virtualUASDialogID := b.virtualUASDialogID
 	b.mu.Unlock()
 
-	// リクエストがAレッグから来たかBレッグから来たかを判断します。
+	// リクエストが仮想UASレッグから来たか仮想UACレッグから来たかを判断します。
 	// これは簡略化されたチェックです。堅牢な実装では、両方のダイアログIDをチェックします。
 	reqDialogID := getDialogID(req.GetHeader("Call-ID"), getTag(req.GetHeader("From")), getTag(req.GetHeader("To")))
 
-	if reqDialogID == aLegDialogID {
-		b.handleALegRequest(req, tx)
+	if reqDialogID == virtualUASDialogID {
+		b.handleVirtualUASRequest(req, tx)
 	} else {
-		b.handleBLegRequest(req, tx)
+		b.handleVirtualUACRequest(req, tx)
 	}
 }
 
-// handleALegRequestは、発呼者（Aレッグ）からのダイアログ内リクエストを処理します。
-func (b *B2BUA) handleALegRequest(req *SIPRequest, tx ServerTransaction) {
+// handleVirtualUASRequestは、発呼者（仮想UASレッグ）からのダイアログ内リクエストを処理します。
+func (b *B2BUA) handleVirtualUASRequest(req *SIPRequest, tx ServerTransaction) {
 	switch req.Method {
 	case "ACK":
-		// 200 OKに対するACKがAレッグで受信されます。Bレッグ用に新しいACKを生成する必要があります。
-		log.Printf("B2BUA: Received ACK for A-leg dialog %s", b.aLegDialogID)
+		// 200 OKに対するACKが仮想UASレッグで受信されます。仮想UACレッグ用に新しいACKを生成する必要があります。
+		log.Printf("B2BUA: Received ACK for Virtual-UAS-leg dialog %s", b.virtualUASDialogID)
 		b.mu.Lock()
-		b.aLegAck = req
+		b.virtualUASAck = req
 		b.mu.Unlock()
 
-		// BレッグのACKを作成して送信します
-		if b.bLegTx != nil && b.bLegTx.LastResponse() != nil {
-			bLegAck := b.createBLegAck(b.bLegTx.LastResponse())
-			if bLegAck != nil {
-				b.bLegTx.Transport().Write([]byte(bLegAck.String()))
-				log.Printf("B2BUA: Sent ACK for B-leg dialog %s", b.bLegDialogID)
+		// 仮想UACレッグのACKを作成して送信します
+		if b.virtualUACTx != nil && b.virtualUACTx.LastResponse() != nil {
+			virtualUACAck := b.createVirtualUACAck(b.virtualUACTx.LastResponse())
+			if virtualUACAck != nil {
+				b.virtualUACTx.Transport().Write([]byte(virtualUACAck.String()))
+				log.Printf("B2BUA: Sent ACK for Virtual-UAC-leg dialog %s", b.virtualUACDialogID)
 			}
 		}
 
 	case "BYE":
-		// AレッグからのBYE。Aレッグに200 OKで応答し、次にBレッグにBYEを送信します。
-		log.Printf("B2BUA: Received BYE for A-leg dialog %s", b.aLegDialogID)
+		// 仮想UASレッグからのBYE。仮想UASレッグに200 OKで応答し、次に仮想UACレッグにBYEを送信します。
+		log.Printf("B2BUA: Received BYE for Virtual-UAS-leg dialog %s", b.virtualUASDialogID)
 		tx.Respond(BuildResponse(200, "OK", req, nil))
 
-		// BレッグのBYEを作成して送信します
-		bLegBye := b.createForwardedRequest(req, b.bLegDialogID)
-		if bLegBye != nil {
-			b.sendRequestOnBLeg(bLegBye)
+		// 仮想UACレッグのBYEを作成して送信します
+		virtualUACBye := b.createForwardedRequest(req, b.virtualUACDialogID)
+		if virtualUACBye != nil {
+			b.sendRequestOnVirtualUACLeg(virtualUACBye)
 		}
 		b.cleanup()
 	}
 }
 
-// handleBLegRequestは、被呼者（Bレッグ）からのダイアログ内リクエストを処理します。
+// handleVirtualUACRequestは、被呼者（仮想UACレッグ）からのダイアログ内リクエストを処理します。
 // 注意：これらはサーバー上で新しいServerTransactionとして到着します。
-func (b *B2BUA) handleBLegRequest(req *SIPRequest, tx ServerTransaction) {
+func (b *B2BUA) handleVirtualUACRequest(req *SIPRequest, tx ServerTransaction) {
 	switch req.Method {
 	case "BYE":
-		// BレッグからのBYE。Bレッグに200 OKで応答し、次にAレッグにBYEを送信します。
-		log.Printf("B2BUA: Received BYE for B-leg dialog %s", b.bLegDialogID)
+		// 仮想UACレッグからのBYE。仮想UACレッグに200 OKで応答し、次に仮想UASレッグにBYEを送信します。
+		log.Printf("B2BUA: Received BYE for Virtual-UAC-leg dialog %s", b.virtualUACDialogID)
 		tx.Respond(BuildResponse(200, "OK", req, nil))
 
-		// AレッグのBYEを作成して送信します
-		aLegBye := b.createForwardedRequest(req, b.aLegDialogID)
-		if aLegBye != nil {
+		// 仮想UASレッグのBYEを作成して送信します
+		virtualUASBye := b.createForwardedRequest(req, b.virtualUASDialogID)
+		if virtualUASBye != nil {
 			// これには、元の発呼者にリクエストを返す必要があります。
-			// このロジックには、AレッグUAへのクライアントトランザクションを作成する方法が必要です。
+			// このロジックには、仮想UASレッグのUAへのクライアントトランザクションを作成する方法が必要です。
 			// この部分は複雑であり、当面は簡略化されます。
-			log.Printf("B2BUA: Need to send BYE to A-leg, but client tx to UAC is not implemented yet.")
+			log.Printf("B2BUA: Need to send BYE to Virtual-UAS-leg, but client tx to UAC is not implemented yet.")
 		}
 		b.cleanup()
 	}
 }
 
-// createBLegAckは、Bレッグの200 OKレスポンスに基づいてBレッグのACKを作成します。
-func (b *B2BUA) createBLegAck(bLegRes *SIPResponse) *SIPRequest {
-	if bLegRes.StatusCode < 200 || bLegRes.StatusCode >= 300 {
+// createVirtualUACAckは、仮想UACレッグの200 OKレスポンスに基づいて仮想UACレッグのACKを作成します。
+func (b *B2BUA) createVirtualUACAck(virtualUACRes *SIPResponse) *SIPRequest {
+	if virtualUACRes.StatusCode < 200 || virtualUACRes.StatusCode >= 300 {
 		return nil
 	}
 
-	bLegToTag := getTag(bLegRes.GetHeader("To"))
-	bLegFromTag := getTag(bLegRes.GetHeader("From"))
-	bLegCallID := bLegRes.GetHeader("Call-ID")
-	bLegCSeq := bLegRes.GetHeader("CSeq")
-	bLegContact := bLegRes.GetHeader("Contact")
+	virtualUACToTag := getTag(virtualUACRes.GetHeader("To"))
+	virtualUACFromTag := getTag(virtualUACRes.GetHeader("From"))
+	virtualUACCallID := virtualUACRes.GetHeader("Call-ID")
+	virtualUACCSeq := virtualUACRes.GetHeader("CSeq")
+	virtualUACContact := virtualUACRes.GetHeader("Contact")
 
-	contactURI, err := ParseSIPURI(bLegContact)
+	contactURI, err := ParseSIPURI(virtualUACContact)
 	if err != nil {
-		log.Printf("B2BUA: Could not parse Contact URI from B-leg 200 OK: %v", err)
+		log.Printf("B2BUA: Could not parse Contact URI from Virtual-UAC-leg 200 OK: %v", err)
 		return nil
 	}
 
@@ -484,11 +482,11 @@ func (b *B2BUA) createBLegAck(bLegRes *SIPResponse) *SIPRequest {
 		URI:    contactURI.String(),
 		Proto:  "SIP/2.0",
 		Headers: map[string]string{
-			"Via":        fmt.Sprintf("SIP/2.0/%s %s;branch=%s", strings.ToUpper(b.bLegTx.Transport().GetProto()), b.server.listenAddr, GenerateBranchID()),
-			"From":       fmt.Sprintf("%s;tag=%s", b.bLegTx.OriginalRequest().GetHeader("From"), bLegFromTag),
-			"To":         fmt.Sprintf("%s;tag=%s", b.bLegTx.OriginalRequest().GetHeader("To"), bLegToTag),
-			"Call-ID":    bLegCallID,
-			"CSeq":       strings.Replace(bLegCSeq, "INVITE", "ACK", 1),
+			"Via":        fmt.Sprintf("SIP/2.0/%s %s;branch=%s", strings.ToUpper(b.virtualUACTx.Transport().GetProto()), b.server.listenAddr, GenerateBranchID()),
+			"From":       fmt.Sprintf("%s;tag=%s", b.virtualUACTx.OriginalRequest().GetHeader("From"), virtualUACFromTag),
+			"To":         fmt.Sprintf("%s;tag=%s", b.virtualUACTx.OriginalRequest().GetHeader("To"), virtualUACToTag),
+			"Call-ID":    virtualUACCallID,
+			"CSeq":       strings.Replace(virtualUACCSeq, "INVITE", "ACK", 1),
 			"Max-Forwards": "70",
 		},
 		Body: []byte{},
@@ -507,11 +505,11 @@ func (b *B2BUA) createForwardedRequest(origReq *SIPRequest, targetDialogID strin
 	return newReq
 }
 
-// sendRequestOnBLegはBレッグで新しいリクエストを送信します。
-func (b *B2BUA) sendRequestOnBLeg(req *SIPRequest) {
-	// これには、Bレッグ用の新しいクライアントトランザクションを作成する必要があります。
-	log.Printf("B2BUA: Sending %s to B-leg", req.Method)
-	b.bLegTx.Transport().Write([]byte(req.String()))
+// sendRequestOnVirtualUACLegは仮想UACレッグで新しいリクエストを送信します。
+func (b *B2BUA) sendRequestOnVirtualUACLeg(req *SIPRequest) {
+	// これには、仮想UACレッグ用の新しいクライアントトランザクションを作成する必要があります。
+	log.Printf("B2BUA: Sending %s to Virtual-UAC-leg", req.Method)
+	b.virtualUACTx.Transport().Write([]byte(req.String()))
 }
 
 // cleanupは、サーバーのダイアログおよびトランザクションマップからB2BUAを削除します。
@@ -519,23 +517,22 @@ func (b *B2BUA) cleanup() {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	log.Printf("B2BUA: Cleaning up dialogs %s and %s", b.aLegDialogID, b.bLegDialogID)
+	log.Printf("B2BUA: Cleaning up dialogs %s and %s", b.virtualUASDialogID, b.virtualUACDialogID)
 
 	// ダイアログマップから削除します
-	if b.aLegDialogID != "" {
-		b.server.dialogs.Delete(b.aLegDialogID)
+	if b.virtualUASDialogID != "" {
+		b.server.dialogs.Delete(b.virtualUASDialogID)
 	}
-	if b.bLegDialogID != "" {
-		b.server.dialogs.Delete(b.bLegDialogID)
+	if b.virtualUACDialogID != "" {
+		b.server.dialogs.Delete(b.virtualUACDialogID)
 	}
 
 	// トランザクションマップから削除します
-	if b.aLegTx != nil {
+	if b.virtualUASTx != nil {
 		b.server.b2buaMutex.Lock()
-		delete(b.server.b2buaByTx, b.aLegTx.ID())
+		delete(b.server.b2buaByTx, b.virtualUASTx.ID())
 		b.server.b2buaMutex.Unlock()
 	}
-
 
 	select {
 	case <-b.done:

--- a/internal/sip/server.go
+++ b/internal/sip/server.go
@@ -801,18 +801,18 @@ func (s *SIPServer) GetActiveSessions() []SessionInfo {
 		b2bua.mu.RLock()
 		defer b2bua.mu.RUnlock()
 
-		if b2bua.aLegTx == nil || b2bua.aLegTx.OriginalRequest() == nil {
+		if b2bua.virtualUASTx == nil || b2bua.virtualUASTx.OriginalRequest() == nil {
 			return true
 		}
 
-		// 同じセッションを2回表示しないようにするため（a-legとb-legの両方のダイアログIDで保存しているため）、
-		// A-legのIDで反復処理している場合にのみアクションを実行します。
+		// 同じセッションを2回表示しないようにするため（Virtual-UAS-legとVirtual-UAC-legの両方のダイアログIDで保存しているため）、
+		// Virtual-UAS-legのIDで反復処理している場合にのみアクションを実行します。
 		// また、ダイアログが完全に確立されていることも確認します。
-		if b2bua.aLegDialogID == "" || key.(string) != b2bua.aLegDialogID {
+		if b2bua.virtualUASDialogID == "" || key.(string) != b2bua.virtualUASDialogID {
 			return true
 		}
 
-		origReq := b2bua.aLegTx.OriginalRequest()
+		origReq := b2bua.virtualUASTx.OriginalRequest()
 		info := SessionInfo{
 			Caller:   origReq.GetHeader("From"),
 			Callee:   origReq.GetHeader("To"),


### PR DESCRIPTION
Refactor B2BUA terminology for clarity.

Based on user feedback, this change refactors the core B2BUA logic to use more descriptive and intuitive names. The goal is to make the code more self-documenting and easier for new developers to understand.

The following changes were made:
- Renamed the concept of an "A-Leg" (the incoming call leg from the UAC) to "VirtualUAS" to better reflect its role as a virtual User Agent Server.
- Renamed the concept of a "B-Leg" (the outgoing call leg to the UAS) to "VirtualUAC" to better reflect its role as a virtual User Agent Client.

This involved changing:
- Struct fields in the `B2BUA` struct.
- Variable names in all related functions.
- Function names (e.g., `createBLegInvite` -> `createVirtualUACInvite`).
- Comments and log messages to reflect the new terminology.

All existing tests pass, ensuring no functionality was changed.