### PR TITLE
Fix: Implement graceful shutdown for web server

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -53,7 +53,7 @@ func main() {
 	// Webサーバーを起動
 	g.Go(func() error {
 		log.Printf("Webサーバーを %s で起動しています", *webAddr)
-		if err := webServer.Run(*webAddr); err != nil {
+		if err := webServer.Run(gCtx, *webAddr); err != nil {
 			log.Printf("Webサーバーでエラーが発生しました: %v", err)
 			return err
 		}


### PR DESCRIPTION
The application was not terminating upon receiving a SIGINT (Ctrl+C) signal because the web server was using `http.ListenAndServe`, which blocks indefinitely.

This commit refactors the web server to use an `http.Server` instance with a `Shutdown` method that is called when the application context is canceled. The main function now passes the cancellable context to the web server, ensuring it terminates correctly as part of the application's shutdown sequence.