### PR TITLE
feat: Web UIでガイダンス設定を構成可能にする

### DIFF
--- a/internal/sip/app_guidance.go
+++ b/internal/sip/app_guidance.go
@@ -20,7 +20,6 @@ import (
 )
 
 const (
-	wavFilePath       = "audio/announcement.wav"
 	rtpSampleRate     = 8000 // PCMUのサンプルレート
 	rtpPacketDuration = 20   // 20msのRTPパケット
 )
@@ -32,6 +31,7 @@ type App struct {
 	peerConnection *webrtc.PeerConnection
 	audioTrack     *webrtc.TrackLocalStaticRTP
 	done           chan struct{} // PeerConnectionが閉じたときに通知するチャネル
+	wavFilePath    string        // 再生するWAVファイルのパス
 
 	// BYEを送信するためのダイアログ状態
 	callID       string
@@ -43,12 +43,13 @@ type App struct {
 }
 
 // NewApp は、新しいガイダンスアプリケーションインスタンスを作成します。
-func NewApp(server *SIPServer, tx ServerTransaction) *App {
+func NewApp(server *SIPServer, tx ServerTransaction, wavFilePath string) *App {
 	return &App{
-		server:   server,
-		inviteTx: tx,
-		cseq:     1, // BYEの初期CSeqは1ですが、INVITEから取得する必要があります
-		done:     make(chan struct{}),
+		server:      server,
+		inviteTx:    tx,
+		wavFilePath: wavFilePath,
+		cseq:        1, // BYEの初期CSeqは1ですが、INVITEから取得する必要があります
+		done:        make(chan struct{}),
 	}
 }
 
@@ -176,9 +177,9 @@ func (a *App) streamWavFile() {
 		a.peerConnection.Close()
 	}()
 
-	file, err := os.Open(wavFilePath)
+	file, err := os.Open(a.wavFilePath)
 	if err != nil {
-		log.Printf("GuidanceApp: Could not open wav file: %v", err)
+		log.Printf("GuidanceApp: Could not open wav file %s: %v", a.wavFilePath, err)
 		return
 	}
 	defer file.Close()

--- a/internal/sip/server_test.go
+++ b/internal/sip/server_test.go
@@ -33,7 +33,7 @@ func TestSipProxy_InviteCancelFlow(t *testing.T) {
 	s, _ := storage.NewStorage(":memory:")
 	defer s.Close()
 	realm := "go-sip.test"
-	server := NewSIPServer(s, realm, "")
+	server := NewSIPServer(s, realm, "", "")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/sip/session_timer_test.go
+++ b/internal/sip/session_timer_test.go
@@ -67,7 +67,7 @@ func TestSipProxy_SessionTimer_RejectsLowSE(t *testing.T) {
 	s, _ := storage.NewStorage(":memory:")
 	defer s.Close()
 	realm := "go-sip.test"
-	server := NewSIPServer(s, realm, "")
+	server := NewSIPServer(s, realm, "", "")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -144,7 +144,7 @@ func TestSipProxy_SessionTimer_HandlesDownstream422(t *testing.T) {
 	s, _ := storage.NewStorage(":memory:")
 	defer s.Close()
 	realm := "go-sip.test"
-	server := NewSIPServer(s, realm, "")
+	server := NewSIPServer(s, realm, "", "")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	serverConn, err := net.ListenPacket("udp", "127.0.0.1:0")
@@ -252,7 +252,7 @@ func TestSipProxy_SessionTimer_UASDoesNotSupport(t *testing.T) {
 	s, _ := storage.NewStorage(":memory:")
 	defer s.Close()
 	realm := "go-sip.test"
-	server := NewSIPServer(s, realm, "")
+	server := NewSIPServer(s, realm, "", "")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	serverConn, err := net.ListenPacket("udp", "127.0.0.1:0")

--- a/internal/web/templates/guidance.html
+++ b/internal/web/templates/guidance.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <title>ガイダンス設定</title>
+    <style>
+        body { font-family: sans-serif; margin: 2em; }
+        nav { margin-bottom: 1em; }
+        nav a { margin-right: 1em; }
+        .success { color: green; }
+        .error { color: red; }
+    </style>
+</head>
+<body>
+    <nav>
+        <a href="/users">ユーザー管理</a>
+        <a href="/sessions">アクティブセッション</a>
+        <a href="/settings/guidance">ガイダンス設定</a>
+    </nav>
+    <h1>ガイダンス設定</h1>
+
+    {{if .Success}}
+    <p class="success">設定が正常に更新されました。</p>
+    {{end}}
+    {{if .Error}}
+    <p class="error">{{.Error}}</p>
+    {{end}}
+
+    <form method="post">
+        <p>
+            <label for="guidance_user">ガイダンスSIPユーザー:</label><br>
+            <input type="text" id="guidance_user" name="guidance_user" value="{{.GuidanceUser}}" required>
+        </p>
+        <p>
+            <label for="guidance_audio">ガイダンス音声ファイルパス:</label><br>
+            <input type="text" id="guidance_audio" name="guidance_audio" value="{{.GuidanceAudio}}" required>
+        </p>
+        <p>
+            <button type="submit">保存</button>
+        </p>
+    </form>
+</body>
+</html>

--- a/internal/web/templates/sessions.html
+++ b/internal/web/templates/sessions.html
@@ -14,8 +14,9 @@
 <body>
     <h1>Active SIP Sessions</h1>
     <nav>
-        <a href="/users">Manage Users</a> |
-        <a href="/sessions">Active Sessions</a>
+        <a href="/users">ユーザー管理</a>
+        <a href="/sessions">アクティブセッション</a>
+        <a href="/settings/guidance">ガイダンス設定</a>
     </nav>
     <table>
         <thead>

--- a/internal/web/templates/users.html
+++ b/internal/web/templates/users.html
@@ -16,8 +16,9 @@
 <body>
     <h1>SIP Server Users</h1>
     <nav>
-        <a href="/users">Manage Users</a> |
-        <a href="/sessions">Active Sessions</a>
+        <a href="/users">ユーザー管理</a>
+        <a href="/sessions">アクティブセッション</a>
+        <a href="/settings/guidance">ガイダンス設定</a>
     </nav>
     <a href="/users/new" class="add-link">Add New User</a>
     <table>


### PR DESCRIPTION
ガイダンスサーバ機能で使用されるSIP-URIと音声ファイルを、Webインターフェースを介して運用者が設定できるようにします。

主な変更点:
- 設定を永続化するために、データベースに`settings`テーブルを追加。
- ストレージ層に、これらの設定を読み書きするための関数を追加。
- `/settings/guidance`に新しいWebページを作成し、運用者がガイダンスのSIPユーザーと音声ファイルパスを表示・更新できるようにした。
- サーバー起動時にDBから設定を読み込み、存在しない場合はデフォルト値を設定するロジックを`main.go`に追加。
- SIPサーバーが、実行時にWeb UIから動的に更新される設定をスレッドセーフな方法で使用するように修正。
- 関連するテストコードを、シグネチャの変更に合わせて修正。