### PR TITLE
Feat: Allow multiple guidance SIP URIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ go.work.sum
 
 # Build outputs
 sip-server
+server
 
 # Editor/IDE
 # .idea/

--- a/internal/sip/server_test.go
+++ b/internal/sip/server_test.go
@@ -33,7 +33,7 @@ func TestSipProxy_InviteCancelFlow(t *testing.T) {
 	s, _ := storage.NewStorage(":memory:")
 	defer s.Close()
 	realm := "go-sip.test"
-	server := NewSIPServer(s, realm, "", "")
+	server := NewSIPServer(s, realm, nil, "")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/sip/session_timer_test.go
+++ b/internal/sip/session_timer_test.go
@@ -67,7 +67,7 @@ func TestSipProxy_SessionTimer_RejectsLowSE(t *testing.T) {
 	s, _ := storage.NewStorage(":memory:")
 	defer s.Close()
 	realm := "go-sip.test"
-	server := NewSIPServer(s, realm, "", "")
+	server := NewSIPServer(s, realm, nil, "")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -144,7 +144,7 @@ func TestSipProxy_SessionTimer_HandlesDownstream422(t *testing.T) {
 	s, _ := storage.NewStorage(":memory:")
 	defer s.Close()
 	realm := "go-sip.test"
-	server := NewSIPServer(s, realm, "", "")
+	server := NewSIPServer(s, realm, nil, "")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	serverConn, err := net.ListenPacket("udp", "127.0.0.1:0")
@@ -252,7 +252,7 @@ func TestSipProxy_SessionTimer_UASDoesNotSupport(t *testing.T) {
 	s, _ := storage.NewStorage(":memory:")
 	defer s.Close()
 	realm := "go-sip.test"
-	server := NewSIPServer(s, realm, "", "")
+	server := NewSIPServer(s, realm, nil, "")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	serverConn, err := net.ListenPacket("udp", "127.0.0.1:0")

--- a/internal/web/templates/guidance.html
+++ b/internal/web/templates/guidance.html
@@ -29,7 +29,8 @@
     <form method="post">
         <p>
             <label for="guidance_user">ガイダンスSIPユーザー:</label><br>
-            <input type="text" id="guidance_user" name="guidance_user" value="{{.GuidanceUser}}" required>
+            <textarea id="guidance_user" name="guidance_user" rows="4" cols="50" required>{{.GuidanceUser}}</textarea>
+            <br><small>複数のユーザーをカンマ区切りで入力します (例: user1, user2, user3)</small>
         </p>
         <p>
             <label for="guidance_audio">ガイダンス音声ファイルパス:</label><br>


### PR DESCRIPTION
This change modifies the application to allow multiple guidance SIP URIs to be configured, whereas previously only one was supported.

The key changes are:
- The `guidance_user` setting in the database is now stored as a comma-separated string.
- The SIP server parses this string into a set for efficient checking of incoming calls.
- The web interface has been updated to use a textarea for entering multiple comma-separated URIs.
- Test files have been updated to match the new function signatures.