### PR TITLE
feat: Web UIからアクティブなSIPコールを切断する機能を追加

### DIFF
--- a/internal/sip/transaction.go
+++ b/internal/sip/transaction.go
@@ -71,6 +71,7 @@ type ServerTransaction interface {
 	Respond(*SIPResponse) error
 	Requests() <-chan *SIPRequest
 	OriginalRequest() *SIPRequest
+	LastResponse() *SIPResponse
 }
 
 // ClientTransaction は、クライアント側のトランザクションを表します。

--- a/internal/sip/transaction_invite_server.go
+++ b/internal/sip/transaction_invite_server.go
@@ -63,6 +63,11 @@ func (tx *InviteServerTx) ID() string { return tx.id }
 func (tx *InviteServerTx) Done() <-chan bool { return tx.done }
 func (tx *InviteServerTx) Requests() <-chan *SIPRequest { return tx.requests }
 func (tx *InviteServerTx) OriginalRequest() *SIPRequest { return tx.originalReq }
+func (tx *InviteServerTx) LastResponse() *SIPResponse {
+	tx.mu.RLock()
+	defer tx.mu.RUnlock()
+	return tx.lastResponse
+}
 
 func (tx *InviteServerTx) Transport() Transport {
 	return tx.transport

--- a/internal/sip/transaction_noninvite_server.go
+++ b/internal/sip/transaction_noninvite_server.go
@@ -111,6 +111,13 @@ func (tx *NonInviteServerTx) OriginalRequest() *SIPRequest {
 	return tx.originalReq
 }
 
+// LastResponseは、このトランザクションで送信された最後のレスポンスを返します。
+func (tx *NonInviteServerTx) LastResponse() *SIPResponse {
+	tx.mu.RLock()
+	defer tx.mu.RUnlock()
+	return tx.lastResponse
+}
+
 func (tx *NonInviteServerTx) Transport() Transport {
 	return tx.transport
 }

--- a/internal/web/templates/sessions.html
+++ b/internal/web/templates/sessions.html
@@ -25,6 +25,7 @@
                 <th>Callee</th>
                 <th>Duration</th>
                 <th>Call-ID</th>
+                <th>アクション</th>
             </tr>
         </thead>
         <tbody>
@@ -35,11 +36,17 @@
                         <td>{{.Callee}}</td>
                         <td>{{.Duration}}</td>
                         <td>{{.CallID}}</td>
+                        <td>
+                            <form action="/sessions/disconnect" method="post" style="margin:0;">
+                                <input type="hidden" name="call_id" value="{{.CallID}}">
+                                <button type="submit">切断</button>
+                            </form>
+                        </td>
                     </tr>
                 {{end}}
             {{else}}
                 <tr>
-                    <td colspan="4">No active sessions.</td>
+                    <td colspan="5">No active sessions.</td>
                 </tr>
             {{end}}
         </tbody>


### PR DESCRIPTION
Webインターフェースから進行中のSIPコールを強制的に切断する機能を追加します。

主な変更点:
- `/sessions` ページに、各アクティブセッションの「切断」ボタンを追加しました。
- `POST /sessions/disconnect` エンドポイントをWebサーバーに実装し、指定された`Call-ID`を持つコールを切断します。
- `SIPServer`に`DisconnectSession`メソッドを追加し、`Call-ID`でB2BUAインスタンスを検索します。
- `B2BUA`に`Disconnect`メソッドを追加し、通話の両方のレッグに`BYE`リクエストを送信して、セッションを正常に終了させます。
- `ServerTransaction`インターフェースに`LastResponse()`メソッドを追加し、`BYE`リクエストの作成を容易にしました。